### PR TITLE
fix toLower() compilation error with latest nim

### DIFF
--- a/sph.nim
+++ b/sph.nim
@@ -1,4 +1,4 @@
-import strutils
+import strutils,unicode
 import private/sphmacros
 
 {.compile: "vendor/sphlib/c/sha0.c".}


### PR DESCRIPTION
fix toLower() compilation error with latest nim by  importing unicode module.